### PR TITLE
Add missing annotation to KeycloakClient

### DIFF
--- a/gateway/prereqs/overlays/dp/keycloak.yaml
+++ b/gateway/prereqs/overlays/dp/keycloak.yaml
@@ -81,7 +81,6 @@ spec:
     firstName: Bob
     username: bob
 ---
----
 apiVersion: keycloak.org/v1alpha1
 kind: KeycloakClient
 metadata:
@@ -89,6 +88,7 @@ metadata:
   namespace: keycloak
   annotations:
     argocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app: kong-demo
 spec:


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

Fixed a problem with the `KeycloakClient` that was missing the `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` annotation